### PR TITLE
Build/run changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,33 @@
 FROM python:3.10-slim-bullseye
 
+# Install dependencies and gosu
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gcc \
-        ffmpeg
+        ffmpeg \
+        curl && \
+        curl -LO https://github.com/tianon/gosu/releases/latest/download/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }') \
+        && chmod 0755 gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }') \
+        && mv gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }') /usr/local/bin/gosu && \
+        rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash user
+
 USER user
 ENV HOME=/home/user
-WORKDIR $HOME
-RUN mkdir -p $HOME/.config && chmod -R 777 $HOME
 ENV PATH="$HOME/.local/bin:$PATH"
-        
+
 WORKDIR $HOME/spotisub
 ENV PATH="/home/uwsgi/.local/bin:${PATH}"
 
-COPY requirements.txt .
-
-RUN pip3 install -r requirements.txt
+COPY main.py init.py entrypoint.sh first_run.sh uwsgi.ini requirements.txt ./
+COPY spotisub spotisub/
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 USER root
-ENV HOME=/home/user
-COPY main.py .
-COPY init.py .
-COPY spotisub spotisub/
-COPY entrypoint.sh .
-COPY first_run.sh .
-COPY uwsgi.ini .
-RUN chmod +x entrypoint.sh
-RUN chmod +x first_run.sh
+RUN chmod +x entrypoint.sh && \
+    chmod +x first_run.sh && \
+    chown -R user:user .
 
-RUN chown -R user:user .
-
-
-USER user
-CMD ["./entrypoint.sh"]
+# CMD runs as root initially but switches to the user inside entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -6,10 +6,7 @@ services:
       dockerfile: Dockerfile
       network: host
     container_name: spotisub
-    user: 1000:1000
     environment:
-      - PUID=1000
-      - PGID=1000
       - TZ=Europe/Rome
       - SPOTIPY_CLIENT_ID=XXXXXXXXXXXXXXXXXXXXXXXX
       - SPOTIPY_CLIENT_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
@@ -22,7 +19,6 @@ services:
     restart: always
     volumes:
       - "./cache:/home/user/spotisub/cache"
-    entrypoint: ./entrypoint.sh
     ports:
       - 5183:5183
     healthcheck:

--- a/docker-compose.tag.yml
+++ b/docker-compose.tag.yml
@@ -6,10 +6,7 @@ services:
       dockerfile: Dockerfile
       network: host
     container_name: spotisub
-    user: 1000:1000
     environment:
-      - PUID=1000
-      - PGID=1000
       - TZ=Europe/Rome
       - SPOTIPY_CLIENT_ID=XXXXXXXXXXXXXXXXXXXXXXXX
       - SPOTIPY_CLIENT_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
@@ -22,7 +19,6 @@ services:
     restart: always
     volumes:
       - "./cache:/home/user/spotisub/cache"
-    entrypoint: ./entrypoint.sh
     ports:
       - 5183:5183
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,7 @@ name: spotisub
 services:
   spotisub:
     container_name: spotisub
-    user: "1000:1000"
     environment:
-      - PUID=1000
-      - PGID=1000
       - TZ=Europe/Rome
       - SPOTIPY_CLIENT_ID=XXXXXXXXXXXXXXXXXXXXXXXX
       - SPOTIPY_CLIENT_SECRET=XXXXXXXXXXXXXXXXXXXXXXXX
@@ -18,7 +15,6 @@ services:
     restart: always
     volumes:
       - "./cache:/home/user/spotisub/cache"
-    entrypoint: ./entrypoint.sh
     ports:
       - 5183:5183
     healthcheck:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,14 @@
 #!/usr/bin/env bash
-uwsgi --ini uwsgi.ini --enable-threads --py-call-uwsgi-fork-hooks --log-4xx --log-5xx --lazy
+# Modify user/group
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+groupmod -o -g "$PGID" user
+usermod -o -u "$PUID" user
+
+# Create cache directory and set permissions
+CACHE_DIR=${CACHE_DIR:-"/home/user/spotisub/cache"}
+mkdir -p ${CACHE_DIR}
+chown -R user:user ${CACHE_DIR}
+
+# Run the application as 'user'
+gosu user uwsgi --ini uwsgi.ini --enable-threads --py-call-uwsgi-fork-hooks --log-4xx --log-5xx --lazy

--- a/install_scripts/install_spotisub_docker.sh
+++ b/install_scripts/install_spotisub_docker.sh
@@ -64,17 +64,12 @@ while true; do
 done
 
 TIMEZONE="$(cat /etc/timezone)"
-PUID=$(id -u $(whoami))
-PGID=$(getent group $(groups $(whoami) | awk '{print $3}') | cut -d: -f3)
 
 echo "name: spotisub" >> "${WORKDIR}/docker-compose.yml"
 echo "services:" >> "${WORKDIR}/docker-compose.yml"
 echo "  spotisub:" >> "${WORKDIR}/docker-compose.yml"
 echo "    container_name: spotisub" >> "${WORKDIR}/docker-compose.yml"
-echo "    user: \"${PUID}:${PGID}\"" >> "${WORKDIR}/docker-compose.yml"
 echo "    environment:" >> "${WORKDIR}/docker-compose.yml"
-echo "      - PUID=${PUID}" >> "${WORKDIR}/docker-compose.yml"
-echo "      - PGID=${PGID}" >> "${WORKDIR}/docker-compose.yml"
 echo "      - TZ=${TIMEZONE}" >> "${WORKDIR}/docker-compose.yml"
 echo "      - SPOTIPY_CLIENT_ID=${SPOTIFY_CLIENT_ID}" >> "${WORKDIR}/docker-compose.yml"
 echo "      - SPOTIPY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}" >> "${WORKDIR}/docker-compose.yml"
@@ -92,7 +87,6 @@ echo "    image: "blastbeng/spotisub:latest"" >> "${WORKDIR}/docker-compose.yml"
 echo "    restart: always" >> "${WORKDIR}/docker-compose.yml"
 echo "    volumes:" >> "${WORKDIR}/docker-compose.yml"
 echo "      - "./cache:/home/user/spotisub/cache"" >> "${WORKDIR}/docker-compose.yml"
-echo "    entrypoint: ./entrypoint.sh" >> "${WORKDIR}/docker-compose.yml"
 echo "    ports:" >> "${WORKDIR}/docker-compose.yml"
 echo "      - \"5183:5183\"" >> "${WORKDIR}/docker-compose.yml"
 echo "    healthcheck:" >> "${WORKDIR}/docker-compose.yml"


### PR DESCRIPTION
**Changes:**
- Simplified the `Dockerfile` to lower layers
- Added `gosu` to execute the application as `user`
- Updated `docker-compose.*` files since `user: 1000:1000` is not needed.
- `entrypoint.sh` now creates the `cache` directory and gives the correct permissions

As mentioned on this issue https://github.com/blastbeng/spotisub/issues/22#issuecomment-2357240001 when user is binding the directory `cache` if the user didn't create the directory running the container the `first_run.sh` script won't be able to write to it prompting `Can't write to Cache` error, this is due to how docker manages volumes (it creates the directory as root), either the user needed to create the directory before starting the container or change permissions manually and then run the script,  So a solution is running the container as `root` to create and give the permissions automatically using the  `entrypoint.sh` so the `first_run.sh` script can write to it.

User can either run  `docker exec -it -u user spotisub ./first_run.sh` or without it.  since `gosu` is running the application as the user is recommended to pass the `-u user` flag to the command.